### PR TITLE
Add get_random_name function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,9 @@ $ pip install git+https://github.com/toshihikoyanase/mong.git
 
 ```python
 >>> import mong
->>> ng = mong.NameGenerator()
->>> ng.get_random_name()
+>>> mong.get_random_name()
 'goofy_robinson'
->>> ng.get_random_name()
+>>> mong.get_random_name()
 'stoic_feynman'
 ```
 

--- a/mong/__init__.py
+++ b/mong/__init__.py
@@ -1,1 +1,2 @@
+from mong.name_generator import get_random_name  # NOQA
 from mong.name_generator import NameGenerator  # NOQA

--- a/mong/name_generator.py
+++ b/mong/name_generator.py
@@ -10,8 +10,7 @@ from typing import Tuple
 class NameGenerator(object):
 
     def __init__(self,
-                 moby_dicts: Optional[Dict[str, List[str]]] = None,
-                 seed: Optional[int] = None) -> None:
+                 moby_dicts: Optional[Dict[str, List[str]]] = None) -> None:
 
         if moby_dicts is None:
             path = os.path.join(os.path.dirname(__file__), 'moby_dict.json')
@@ -19,7 +18,6 @@ class NameGenerator(object):
         else:
             self._left = moby_dicts['left']
             self._right = moby_dicts['right']
-        self._rng = random.Random(seed)
 
     def _load_dict(self, path: str) -> Tuple[List[str], List[str]]:
 
@@ -38,12 +36,20 @@ class NameGenerator(object):
         retry is specified.
         """
 
-        name = '{}_{}'.format(self._rng.choice(self._left), self._rng.choice(self._right))
+        name = '{}_{}'.format(random.choice(self._left), random.choice(self._right))
 
         # Steve Wozniak is not boring.
         if name == 'boring_wozniak':
             return self.get_random_name(retry)
 
         if retry > 0:
-            name = '{}{}'.format(name, self._rng.randint(0, 9))
+            name = '{}{}'.format(name, random.randint(0, 9))
         return name
+
+
+_name_generator = NameGenerator()
+
+
+def get_random_name(retry: int = 0) -> str:
+
+    return _name_generator.get_random_name(retry)

--- a/tests/test_name_generator.py
+++ b/tests/test_name_generator.py
@@ -42,3 +42,16 @@ class TestNameGenerator(unittest.TestCase):
         ng = mong.NameGenerator({'left': ['boring'], 'right': ['wozniak', 'tom']})
         for _ in range(4):
             self.assertEqual(ng.get_random_name(), 'boring_tom')
+
+    def test_get_random_name(self):
+        name = mong.get_random_name()
+        self.assertTrue('_' in name)
+        self.assertTrue(self._re_number.search(name) is None)
+
+        name = mong.get_random_name(0)
+        self.assertTrue('_' in name)
+        self.assertTrue(self._re_number.search(name) is None)
+
+        name = mong.get_random_name(1)
+        self.assertTrue('_' in name)
+        self.assertTrue(self._re_number.search(name) is not None)


### PR DESCRIPTION
This PR adds `mong.get_random_name` function for users to generate names without instance creation. Please note that the `seed` option of `NameGenerator` was removed, and the global random number generator is used. This change enables users to set random seeds for `mong.get_random_name` via `random.seed`.