### PR TITLE
Refactor create_dict.py. 

### DIFF
--- a/mong/create_dict.py
+++ b/mong/create_dict.py
@@ -4,10 +4,10 @@ from typing import Dict
 from typing import List
 import urllib.request
 
+GO_URL = 'https://raw.githubusercontent.com/moby/moby/master/pkg/namesgenerator/names-generator.go'
 
-def download_go_code() -> str:
-    url = \
-        'https://raw.githubusercontent.com/moby/moby/master/pkg/namesgenerator/names-generator.go'
+
+def download_go_code(url: str) -> str:
 
     with urllib.request.urlopen(url) as response:
         code = response.read()
@@ -15,6 +15,7 @@ def download_go_code() -> str:
 
 
 def extract_dict(code: str) -> Dict[str, List[str]]:
+
     is_left = False
     is_right = False
 
@@ -53,9 +54,13 @@ def extract_dict(code: str) -> Dict[str, List[str]]:
     }
 
 
-if __name__ == '__main__':
-    moby_dict = extract_dict(download_go_code())
-    path = 'mong/moby_dict.json'
-    with open(path, 'w') as fout:
+def create_dict(url: str, filepath: str) -> None:
+
+    go_code = download_go_code(url)
+    moby_dict = extract_dict(go_code)
+    with open(filepath, 'w') as fout:
         json.dump(moby_dict, fout, indent=4)
-    print('Save moby dict to {}.'.format(path))
+
+
+if __name__ == '__main__':
+    create_dict(GO_URL, 'mong/moby_dict.json')

--- a/tests/test_create_dict.py
+++ b/tests/test_create_dict.py
@@ -1,3 +1,7 @@
+import json
+import os
+import shutil
+import tempfile
 import unittest
 
 import mong.create_dict
@@ -5,34 +9,57 @@ import mong.create_dict
 
 class TestCreateDict(unittest.TestCase):
 
+    def setUp(self):
+
+        self.tmp_dir = tempfile.mkdtemp()
+        self.go_file = os.path.join(self.tmp_dir, 'namesgenerator.go')
+        self.go_url = 'file://{}'.format(self.go_file)
+        self.go_code = """
+        var (
+            left = [...]string{
+                "admiring",
+                "zen",
+            }
+            right = [...]string{
+                // Muhammad ibn Jābir al-Ḥarrānī al-Battānī
+                "albattani",
+
+                // Frances E. Allen
+                "allen",
+            }
+        )
+        """
+
+        with open(self.go_file, 'w') as fout:
+            print(self.go_code, file=fout)
+
     def test_download_go_code(self):
 
-        code = mong.create_dict.download_go_code()
+        code = mong.create_dict.download_go_code(self.go_url)
 
         self.assertTrue('left =' in code)
         self.assertTrue('right =' in code)
 
     def test_extract_dict(self):
 
-        code = """
-var (
-    left = [...]string{
-        "admiring",
-        "zen",
-    }
-    right = [...]string{
-        // Muhammad ibn Jābir al-Ḥarrānī al-Battānī
-        "albattani",
-
-        // Frances E. Allen
-        "allen",
-    }
-)
-        """
-
-        moby_dict = mong.create_dict.extract_dict(code)
+        moby_dict = mong.create_dict.extract_dict(self.go_code)
 
         self.assertTrue('left' in moby_dict)
         self.assertTrue('right' in moby_dict)
         self.assertEqual(moby_dict['left'], ['admiring', 'zen'])
         self.assertEqual(moby_dict['right'], ['albattani', 'allen'])
+
+    def test_create_dict(self):
+
+        tmp_file = os.path.join(self.tmp_dir, 'tmp_dict.json')
+        mong.create_dict.create_dict(self.go_url, tmp_file)
+
+        with open(tmp_file) as fin:
+            moby_dict = json.load(fin)
+
+        self.assertTrue('left' in moby_dict)
+        self.assertTrue('right' in moby_dict)
+
+    def tearDown(self):
+
+        shutil.rmtree(self.tmp_dir)


### PR DESCRIPTION
This change will improve test coverage. It adds `create_dict` function which extracts untested codes in `__main__`. And also, it improves the robustness of unittest by removing the external access to the original go code.

The following internal function will be also changed:
- `download_go_code` function requires the `url` argument which specifies the URL of the original go code.
- `test_create_dict.py` assumes Unix-like file paths. It may not work on Windows OS.