### PR TITLE
Add GitHub Action to publish Python package.

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,4 +1,4 @@
-name: Publish Python distributions to TestPyPI
+name: Publish Python distributions to TestPyPI and PyPI
 
 # Only activate if we add the v* tag to the master branch.
 on:
@@ -45,3 +45,11 @@ jobs:
         user: __token__
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
+
+    - name: Publish distribution to PyPI
+      # Do not upload the package from forked repository.
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')  && github.repository == 'toshihikoyanase/mong'
+      uses: pypa/gh-action-pypi-publish@v1.1.0
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,47 @@
+name: Publish Python distributions to TestPyPI
+
+# Only activate if we add the v* tag to the master branch.
+on:
+  push:
+    branches:
+    - master
+    tags:
+    - v*
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python distributions to TestPyPI
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+
+    - name: Install twine
+      run: >-
+        python -m pip install --user twine
+
+    - name: Build a tar ball
+      run: >-
+        python setup.py sdist
+
+    - name: Verify the distributions
+      run: twine check dist/*
+
+    # Save the package to the GitHub Actions' artifact.
+    - name: Save dist dir
+      uses: actions/upload-artifact@v1
+      with:
+        name: optuna-dist
+        path: dist
+
+    - name: Publish distribution to Test PyPI
+      # Do not upload the package from forked repository.
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')  && github.repository == 'toshihikoyanase/mong'
+      uses: pypa/gh-action-pypi-publish@v1.1.0
+      with:
+        user: __token__
+        password: ${{ secrets.test_pypi_password }}
+        repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-n-publish:
-    name: Build and publish Python distributions to TestPyPI
+    name: Build and publish Python distributions to TestPyPI and PyPI
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This PR introduces [pypi-publish](https://github.com/marketplace/actions/pypi-publish) to release Python package at PyPI and TestPyPI. It will be triggered when the `v*` tag is pushed to the master branch.