### PR TITLE
Remove on-push-branch from pypi-publish.yml.

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -17,6 +17,10 @@ jobs:
       with:
         python-version: 3.7
 
+    - name: Install twine
+      run: >-
+        python -m pip install -U twine
+
     - name: Build a tar ball
       run: >-
         python setup.py sdist

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,10 +1,8 @@
 name: Publish Python distributions to TestPyPI and PyPI
 
-# Only activate if we add the v* tag to the master branch.
+# Only activate if the v* tag is pushed.
 on:
   push:
-    branches:
-    - master
     tags:
     - v*
 
@@ -18,10 +16,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
-
-    - name: Install twine
-      run: >-
-        python -m pip install --user twine
 
     - name: Build a tar ball
       run: >-


### PR DESCRIPTION
This PR is a followup for #26 .

- Activate actions only if the tag `v*` is pushed.
- Install twine globally.