### PR TITLE
Bump up version to `0.0.3a`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def load_readme() -> str:
 
 setup(
     name="mong",
-    version="0.0.2",
+    version="0.0.3a",
     description="Moby Name Generator in Python",
     long_description=load_readme(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This version is mainly for pypi-release tests.