### PR TITLE
Add a marker file of PEP 561 compliant.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,5 @@ setup(
         "Programming Language :: Python :: 3 :: Only",
     ],
     packages=["mong"],
-    package_data={"mong": ["moby_dict.json"]},
+    package_data={"mong": ["moby_dict.json", "py.typed"]},
 )


### PR DESCRIPTION
## Motivation

The current release (v0.03a) causes the following error when users apply mypy to files.

```python
import mong

def sample() -> str:
    return mong.get_random_name()
```

```console
$ mypy sample.py 
sample.py:1: error: Skipping analyzing 'mong': found module but no type hints or library stubs
sample.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 1 source file)
```

This is due to the lack of the package type information defined by [PEP 561](https://www.python.org/dev/peps/pep-0561/).

## Changes

This PR adds `mong/py.typed` which is a marker file of the package type information.