### PR TITLE
Remove `codecov` token.

### DIFF
--- a/.github/workflows/pythonfull.yml
+++ b/.github/workflows/pythonfull.yml
@@ -34,5 +34,3 @@ jobs:
         coverage xml
     - name: Report code coverage
       uses: codecov/codecov-action@v1
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Remove Codecov token because it is required for private repositories.