### PR TITLE
Update Python and GitHub Actions

### DIFF
--- a/.github/workflows/check-dict-update.yml
+++ b/.github/workflows/check-dict-update.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -9,13 +9,13 @@ on:
 jobs:
   build-n-publish:
     name: Build and publish Python distributions to TestPyPI and PyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: '3.10'
 
     - name: Install twine
       run: >-
@@ -29,17 +29,10 @@ jobs:
     - name: Verify the distributions
       run: twine check dist/*
 
-    # Save the package to the GitHub Actions' artifact.
-    - name: Save dist dir
-      uses: actions/upload-artifact@v1
-      with:
-        name: optuna-dist
-        path: dist
-
     - name: Publish distribution to Test PyPI
       # Do not upload the package from forked repository.
       if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')  && github.repository == 'toshihikoyanase/mong'
-      uses: pypa/gh-action-pypi-publish@v1.1.0
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.test_pypi_password }}
@@ -48,7 +41,7 @@ jobs:
     - name: Publish distribution to PyPI
       # Do not upload the package from forked repository.
       if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')  && github.repository == 'toshihikoyanase/mong'
-      uses: pypa/gh-action-pypi-publish@v1.1.0
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}

--- a/.github/workflows/pythonfull.yml
+++ b/.github/workflows/pythonfull.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pythontest.yml
+++ b/.github/workflows/pythontest.yml
@@ -9,11 +9,11 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mong
 
-[![Python](https://img.shields.io/badge/python-3.6%20%7C%203.7%20%7C%203.8%20%7C%203.9-blue)](https://www.python.org)
+[![Python](https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue)](https://www.python.org)
 [![pypi](https://img.shields.io/pypi/v/mong.svg)](https://pypi.python.org/pypi/mong)
 ![](https://github.com/toshihikoyanase/mong/workflows/test/badge.svg)
 [![codecov](https://codecov.io/gh/toshihikoyanase/mong/branch/master/graph/badge.svg)](https://codecov.io/gh/toshihikoyanase/mong)


### PR DESCRIPTION
## Changes

- Update Python
  - Remove support for Python 3.6 due to its end-of-life
  - Add support for Python 3.10, 3.11, 3.12
- Update GitHub Actions
  - Replace actions/checks@v1 with v3
  - Replace ubuntu-18.04 with ubuntu-latest
  - Replace actions/setup-python@v1 with v4
  - Replace pypa/gh-action-pypi-publish@v1.1.0 with release/v1

In addition, unnecessary steps such as artifact upload were removed in this PR.