### PR TITLE
Update GitHub Actions and support Python versions.

### DIFF
--- a/.github/workflows/check-dict-update.yml
+++ b/.github/workflows/check-dict-update.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -11,11 +11,11 @@ jobs:
     name: Build and publish Python distributions to TestPyPI and PyPI
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.10
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
 
     - name: Install twine
       run: >-

--- a/.github/workflows/pythonfull.yml
+++ b/.github/workflows/pythonfull.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -33,4 +33,4 @@ jobs:
         coverage run -m unittest discover tests
         coverage xml
     - name: Report code coverage
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v5

--- a/.github/workflows/pythontest.yml
+++ b/.github/workflows/pythontest.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pythontest.yml
+++ b/.github/workflows/pythontest.yml
@@ -9,11 +9,11 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .mypy_cache/
 build/
 dist/
+*.egg-info/
 
 *.go
 *.pyc

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mong
 
-[![Python](https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue)](https://www.python.org)
+[![Python](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org)
 [![pypi](https://img.shields.io/pypi/v/mong.svg)](https://pypi.python.org/pypi/mong)
 ![](https://github.com/toshihikoyanase/mong/workflows/test/badge.svg)
 [![codecov](https://codecov.io/gh/toshihikoyanase/mong/branch/master/graph/badge.svg)](https://codecov.io/gh/toshihikoyanase/mong)


### PR DESCRIPTION
## Motivation
This pull request updates the GitHub Actions workflows to use the latest versions of actions and Python.
In addition, it removes Python 3.7 support and adds Python 3.13 support.

## Changes

Updates to GitHub Actions workflows:

* Update default Python version from 3.10 to 3.12 in the workflows
* Update actions/checkout version from v3 to v4
* Update actions/setup-python version from v4 to v5
* Update codecov/codecov-action from v1 to v5