### PR TITLE
Disable attestations tentatively

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -36,7 +36,8 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.test_pypi_password }}
-        repository_url: https://test.pypi.org/legacy/
+        repository-url: https://test.pypi.org/legacy/
+        attestations: false
 
     - name: Publish distribution to PyPI
       # Do not upload the package from forked repository.
@@ -45,3 +46,4 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}
+        attestations: false


### PR DESCRIPTION
This pull request includes minor updates to the `.github/workflows/pypi-publish.yml` file, focusing on the configuration of the publishing jobs.

Changes to `jobs:` in `.github/workflows/pypi-publish.yml`:

* Changed `repository_url` to `repository-url` and added `attestations: false` in the test PyPI publishing job.
* Added `attestations: false` to the main PyPI publishing job.