### PR TITLE
Bump up version to 0.0.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def load_readme() -> str:
 
 setup(
     name="mong",
-    version="0.0.3a3",
+    version="0.0.3",
     description="Moby Name Generator in Python",
     long_description=load_readme(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This pull request includes a small change to the `setup.py` file. The change updates the version of the `mong` package from `0.0.3a3` to `0.0.3`.

Changes in `setup.py`:

* Updated the `version` field from `0.0.3a3` to `0.0.3`.