### PR TITLE
Add `setuptools` to publish package.

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -19,7 +19,7 @@ jobs:
 
     - name: Install twine
       run: >-
-        python -m pip install -U twine wheel
+        python -m pip install -U twine wheel setuptools
 
     - name: Build a tar ball
       run: |


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/pypi-publish.yml` file.
The change updates the pip install command to include `setuptools` along with `twine` and `wheel`.
